### PR TITLE
Adds multi-container support for cron execution

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,8 +6,8 @@ import (
 
 	"gopkg.in/robfig/cron.v2"
 
+	"github.com/nowait-tools/rancher-cron/metadata"
 	"github.com/socialengine/rancher-cron/cattle"
-	"github.com/socialengine/rancher-cron/metadata"
 	"github.com/socialengine/rancher-cron/model"
 
 	"github.com/Sirupsen/logrus"


### PR DESCRIPTION
This came from a need to run ElasticSearch curator containers where each master server runs a curator container that decides if it is on the cluster's elected master server.

This keeps the original functionality as well as allowing you to run multiple containers. 
