### PR TITLE
Disable cron for "Stopped" services

### DIFF
--- a/cattle/cattle.go
+++ b/cattle/cattle.go
@@ -28,6 +28,25 @@ func NewClient(cattleURL string, cattleAccessKey string, cattleSecretKey string)
 	}, nil
 }
 
+// GetServiceByUUID grabs a Service given a UUID
+func (c *Client) GetServiceByUUID(uuid string) (*client.Service, error) {
+	opts := &client.ListOpts{
+		Filters: map[string]interface{}{
+			"uuid": uuid,
+		},
+	}
+
+	services, err := c.rancherClient.Service.List(opts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	service := &services.Data[0]
+
+	return service, err
+}
+
 // GetContainerByUUID grabs a Container given a UUID
 func (c *Client) GetContainerByUUID(uuid string) (*client.Container, error) {
 	opts := &client.ListOpts{

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -32,7 +32,7 @@ func NewClient(cronLabelName string) (*Client, error) {
 	}
 
 	return &Client{
-		MetadataClient:  m,
+		MetadataClient:  *m,
 		EnvironmentName: envName,
 		CronLabelName:   cronLabelName,
 	}, nil
@@ -77,7 +77,7 @@ func (m *Client) GetContainersFromService(service metadata.Service) ([]string, e
 	return uuids, fmt.Errorf("could not find container UUID with %s", m.CronLabelName)
 }
 
-func getEnvironmentName(m metadata.Client) (string, error) {
+func getEnvironmentName(m *metadata.Client) (string, error) {
 	timeout := 30 * time.Second
 	var err error
 	var stack metadata.Stack

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/socialengine/rancher-cron/model"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/rancher/go-rancher-metadata/metadata"
 )
@@ -19,7 +17,6 @@ type Client struct {
 	MetadataClient  metadata.Client
 	EnvironmentName string
 	CronLabelName   string
-	Schedules       *model.Schedules
 }
 
 // NewClient creates a new metadata client
@@ -34,13 +31,10 @@ func NewClient(cronLabelName string) (*Client, error) {
 		logrus.Fatalf("Error reading stack info: %v", err)
 	}
 
-	schedules := make(model.Schedules)
-
 	return &Client{
 		MetadataClient:  m,
 		EnvironmentName: envName,
 		CronLabelName:   cronLabelName,
-		Schedules:       &schedules,
 	}, nil
 }
 
@@ -49,55 +43,13 @@ func (m *Client) GetVersion() (string, error) {
 	return m.MetadataClient.GetVersion()
 }
 
-// GetCronSchedules returns a map of schedules with ContainerUUID as a key
-func (m *Client) GetCronSchedules() (*model.Schedules, error) {
-	schedules := *m.Schedules
-	services, err := m.MetadataClient.GetServices()
-
-	if err != nil {
-		logrus.Infof("Error reading services %v", err)
-		return &schedules, err
-	}
-
-	markScheduleForCleanup(m.Schedules)
-
-	for _, service := range services {
-		cronExpression, ok := service.Labels[m.CronLabelName]
-		if !ok {
-			continue
-		}
-		containerUUIDs, err := m.getCronContainers(service)
-		if err != nil {
-			continue
-		}
-
-		for _, containerUUID := range containerUUIDs {
-			existingSchedule, ok := schedules[containerUUID]
-			// we already have schedule for this container
-			if ok {
-				// do not cleanup
-				existingSchedule.ToCleanup = false
-
-				logrus.WithFields(logrus.Fields{
-					"uuid":           containerUUID,
-					"cronExpression": cronExpression,
-				}).Debugf("already have container")
-
-				continue
-			}
-			//label exists, configure schedule
-			schedule := model.NewSchedule()
-
-			schedule.CronExpression = cronExpression
-			schedule.ContainerUUID = containerUUID
-			schedules[containerUUID] = schedule
-		}
-	}
-
-	return &schedules, nil
+// GetServices returns the services from the metadata client
+func (m *Client) GetServices() ([]metadata.Service, error) {
+	return m.MetadataClient.GetServices()
 }
 
-func (m *Client) getCronContainers(service metadata.Service) ([]string, error) {
+// GetContainersFromService returns an array of UUIDs for the containers within a service
+func (m *Client) GetContainersFromService(service metadata.Service) ([]string, error) {
 	containers := service.Containers
 	var uuids []string
 
@@ -123,12 +75,6 @@ func (m *Client) getCronContainers(service metadata.Service) ([]string, error) {
 	}
 
 	return uuids, fmt.Errorf("could not find container UUID with %s", m.CronLabelName)
-}
-
-func markScheduleForCleanup(schedules *model.Schedules) {
-	for _, schedule := range *schedules {
-		schedule.ToCleanup = true
-	}
 }
 
 func getEnvironmentName(m metadata.Client) (string, error) {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -16,7 +16,7 @@ const (
 
 // Client is a Struct that holds all metadata-specific data
 type Client struct {
-	MetadataClient  *metadata.Client
+	MetadataClient  metadata.Client
 	EnvironmentName string
 	CronLabelName   string
 	Schedules       *model.Schedules
@@ -131,7 +131,7 @@ func markScheduleForCleanup(schedules *model.Schedules) {
 	}
 }
 
-func getEnvironmentName(m *metadata.Client) (string, error) {
+func getEnvironmentName(m metadata.Client) (string, error) {
 	timeout := 30 * time.Second
 	var err error
 	var stack metadata.Stack

--- a/model/schedule.go
+++ b/model/schedule.go
@@ -1,9 +1,6 @@
 package model
 
-import (
-	"github.com/rancher/go-rancher/client"
-	"gopkg.in/robfig/cron.v2"
-)
+import "gopkg.in/robfig/cron.v2"
 
 // Schedule holds data related to an individual schedule such as cronId, schedule, ContainerUUID, etc
 type Schedule struct {
@@ -11,7 +8,7 @@ type Schedule struct {
 	CronExpression string
 	ContainerUUID  string
 	CronID         cron.EntryID
-	Container      client.Container
+	ServiceUUID    string
 }
 
 // Schedules is a simple collection of Schedule

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,0 +1,93 @@
+package scheduler
+
+import (
+	"github.com/Sirupsen/logrus"
+
+	"github.com/socialengine/rancher-cron/cattle"
+	"github.com/socialengine/rancher-cron/metadata"
+	"github.com/socialengine/rancher-cron/model"
+)
+
+// Scheduler is a Struct and contains all the schedule info
+type Scheduler struct {
+	CattleClient   *cattle.Client
+	MetadataClient *metadata.Client
+	CronLabelName  string
+	Schedules      *model.Schedules
+}
+
+// NewScheduler creates a new Scheduler
+func NewScheduler(cronLabelName string, metadataClient *metadata.Client, cattleClient *cattle.Client) (*Scheduler, error) {
+	schedules := make(model.Schedules)
+
+	return &Scheduler{
+		CattleClient:   cattleClient,
+		MetadataClient: metadataClient,
+		CronLabelName:  cronLabelName,
+		Schedules:      &schedules,
+	}, nil
+}
+
+// GetCronSchedules returns a map of schedules with ContainerUUID as a key
+func (m *Scheduler) GetCronSchedules() (*model.Schedules, error) {
+	schedules := *m.Schedules
+	services, err := m.MetadataClient.GetServices()
+
+	if err != nil {
+		logrus.Infof("Error reading services %v", err)
+		return &schedules, err
+	}
+
+	markScheduleForCleanup(m.Schedules)
+
+	for _, service := range services {
+		cronExpression, ok := service.Labels[m.CronLabelName]
+		if !ok {
+			continue
+		}
+
+		cattleService, err := m.CattleClient.GetServiceByUUID(service.UUID)
+		if err == nil {
+			if cattleService.State == "inactive" {
+				logrus.Debugf("ignoring inactive service uuid %s", service.UUID)
+				continue
+			}
+		}
+
+		containerUUIDs, err := m.MetadataClient.GetContainersFromService(service)
+		if err != nil {
+			continue
+		}
+
+		for _, containerUUID := range containerUUIDs {
+			existingSchedule, ok := schedules[containerUUID]
+			// we already have schedule for this container
+			if ok {
+				// do not cleanup
+				existingSchedule.ToCleanup = false
+
+				logrus.WithFields(logrus.Fields{
+					"uuid":           containerUUID,
+					"cronExpression": cronExpression,
+				}).Debugf("already have container")
+
+				continue
+			}
+			//label exists, configure schedule
+			schedule := model.NewSchedule()
+
+			schedule.CronExpression = cronExpression
+			schedule.ContainerUUID = containerUUID
+			schedule.ServiceUUID = service.UUID
+			schedules[containerUUID] = schedule
+		}
+	}
+
+	return &schedules, nil
+}
+
+func markScheduleForCleanup(schedules *model.Schedules) {
+	for _, schedule := range *schedules {
+		schedule.ToCleanup = true
+	}
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -47,11 +47,9 @@ func (m *Scheduler) GetCronSchedules() (*model.Schedules, error) {
 		}
 
 		cattleService, err := m.CattleClient.GetServiceByUUID(service.UUID)
-		if err == nil {
-			if cattleService.State == "inactive" {
-				logrus.Debugf("ignoring inactive service uuid %s", service.UUID)
-				continue
-			}
+		if err == nil && cattleService.State == "inactive" {
+			logrus.Debugf("ignoring inactive service uuid %s", service.UUID)
+			continue
 		}
 
 		containerUUIDs, err := m.MetadataClient.GetContainersFromService(service)


### PR DESCRIPTION
I took a stab at #9.  First, I updated the metadata.go since the rancher metadata api had changed slightly and broke this (NewClientAndWait no longer returns a pointer).  In the second commit, I made it so that GetCronSchedules looks up the service in the cattle service to get the service state.  If the state is inactive it ignores it and allows it to be removed from the schedule.  The scheduling used to happen in metadata.go but it didn't make sense for metadata.go to depend on cattle.go so I introduced a new scheduler.go.  This now contains all of the scheduling logic, leaving metadata.go and cattle.go as thin wrappers around those respective rancher services.

I tested this with Rancher releases 1.1.2 and 1.2.0 and it seems to work ok for both.

I'm new to go, so please let me know if there are any changes you want.