### PR TITLE
add dumb-init + running as unprivileged user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,16 @@
 FROM alpine:3.5
 MAINTAINER SocialEngine
-RUN apk add --update ca-certificates 
+
+ENV DUMP_INIT_VERSION 1.2.0
 
 ADD dist/rancher-cron /usr/bin/rancher-cron
+ADD https://github.com/Yelp/dumb-init/releases/download/v${DUMP_INIT_VERSION}/dumb-init_${DUMP_INIT_VERSION}_amd64 /usr/bin/dumb-init
 
-CMD ["rancher-cron"]
+RUN \
+  adduser -s /sbin/nologin -u 1000 -D rancher-cron && \
+  apk add --no-cache ca-certificates && \
+  chmod +x /usr/bin/dumb-init
+
+USER rancher-cron
+
+CMD [ "dumb-init", "rancher-cron" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.5
 MAINTAINER SocialEngine
 RUN apk add --update ca-certificates 
 


### PR DESCRIPTION
# Update rancher-cron

- add [dumb-init](https://github.com/Yelp/dumb-init) to [prevent zombie reaping problem](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/).
- add security by running as unprivileged user

and thanks for the service!
i was looking for a way to run my [cloudflare-dynamic-dns-updater](https://hub.docker.com/r/ellerbrock/alpine-cloudflare-dyndns/) and other small services in a scheduled way without the need of sleep and lots of running containers ...

![yolo](http://i.giphy.com/aLdiZJmmx4OVW.gif)